### PR TITLE
simplify envoy image

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -32,9 +32,7 @@ services:
 
   envoy:
     build:
-      context: ./
-      dockerfile: ./envoy/Dockerfile
-    image: grpcweb/envoy
+      context: ./envoy
     volumes:
       - ./envoy:/etc/envoy
     ports:

--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -17,4 +17,4 @@ FROM envoyproxy/envoy:v1.28.0
 COPY envoy.yaml /etc/envoy/envoy.yaml
 
 ENTRYPOINT [ "/usr/local/bin/envoy" ]
-CMD [ "-c /etc/envoy/envoy.yaml", "-l trace", "--log-path /tmp/envoy_info.log" ]
+CMD [ "-c", "/etc/envoy/envoy.yaml", "-l", "trace", "--log-path", "/tmp/envoy_info.log" ]

--- a/envoy/Dockerfile
+++ b/envoy/Dockerfile
@@ -14,6 +14,7 @@
 
 FROM envoyproxy/envoy:v1.28.0
 
-COPY envoy/envoy.yaml /etc/envoy/envoy.yaml
+COPY envoy.yaml /etc/envoy/envoy.yaml
 
-CMD /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l trace --log-path /tmp/envoy_info.log
+ENTRYPOINT [ "/usr/local/bin/envoy" ]
+CMD [ "-c /etc/envoy/envoy.yaml", "-l trace", "--log-path /tmp/envoy_info.log" ]


### PR DESCRIPTION
Specifying `image: grpcweb/envoy` on docker-compose.yaml is redundant, we already use a Dockerfile

The `grpcweb/envoy` image is defined in https://github.com/grpc/grpc-web/blob/master/net/grpc/gateway/docker/envoy/Dockerfile

```dockerfile
FROM envoyproxy/envoy:v1.22.0

COPY net/grpc/gateway/examples/echo/envoy.yaml /etc/envoy/envoy.yaml

ENTRYPOINT [ "/usr/local/bin/envoy" ]
CMD [ "-c /etc/envoy/envoy.yaml", "-l trace", "--log-path /tmp/envoy_info.log" ]
```

so we can safely remove the `grpcweb/envoy` to avoid confusion.